### PR TITLE
Fix Invalid Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning][semver].
   current token and raises `UnableToRefreshTokenException` when token couldn't
   be refreshed.
 - Client secret is now saved in token file JSON file.
+- Cleaned up exceptions.
 
 ## [v0.10.1][v0.10.1] - 2017-09-24
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ adheres to [Semantic Versioning][semver].
 - `MonzoAPI()._refresh_oath_token()` now doesn't return anything, replaces
   current token and raises `UnableToRefreshTokenException` when token couldn't
   be refreshed.
+- Client secret is now saved in token file JSON file.
 
 ## [v0.10.1][v0.10.1] - 2017-09-24
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog][keepachangelog] and this project
 adheres to [Semantic Versioning][semver].
 
 ## [Unreleased][unreleased]
+### Fixed
+- Fixed automatic token refreshing - thanks @bartonp! (#5)
+
 ### Changed
 - `MonzoAPI()._refresh_oath_token()` now doesn't return anything, replaces
   current token and raises `UnableToRefreshTokenException` when token couldn't

--- a/src/pymonzo/exceptions.py
+++ b/src/pymonzo/exceptions.py
@@ -15,6 +15,11 @@ class MonzoAPIException(PyMonzoException):
     pass
 
 
+class UnableToGetToken(PyMonzoException):
+    """Unable to get a token generic"""
+    pass
+
+
 class UnableToRefreshTokenException(MonzoAPIException):
     """Base Monzo API response exception"""
     pass

--- a/src/pymonzo/exceptions.py
+++ b/src/pymonzo/exceptions.py
@@ -10,16 +10,11 @@ class PyMonzoException(Exception):
     pass
 
 
-class MonzoAPIException(PyMonzoException):
+class MonzoAPIError(PyMonzoException):
     """Monzo API response exception"""
     pass
 
 
-class UnableToGetToken(PyMonzoException):
-    """Unable to get a token generic"""
-    pass
-
-
-class UnableToRefreshTokenException(MonzoAPIException):
+class CantRefreshTokenError(MonzoAPIError):
     """Base Monzo API response exception"""
     pass

--- a/src/pymonzo/monzo_api.py
+++ b/src/pymonzo/monzo_api.py
@@ -71,10 +71,13 @@ class MonzoAPI(CommonMixin):
             self._auth_code = auth_code
 
             self._token = self._get_oauth_token()
-        # c) token file saved on the disk
+        # c) token file saved on the disk and possibly passing in 'client_secret'
         elif os.path.isfile(config.TOKEN_FILE_PATH):
             with codecs.open(config.TOKEN_FILE_PATH, 'r', 'utf-8') as f:
                 self._token = json.load(f)
+            self._client_id = self._token['client_id']
+            if client_secret is not None:
+                self._client_secret = client_secret
         # d) 'access_token' saved as a environment variable
         elif os.getenv(config.MONZO_ACCESS_TOKEN_ENV):
             self._access_token = os.getenv(config.MONZO_ACCESS_TOKEN_ENV)

--- a/tests/test_monzo_api.py
+++ b/tests/test_monzo_api.py
@@ -117,7 +117,7 @@ class TestMonzoAPI:
         monzo = MonzoAPI()
 
         assert monzo._access_token is None
-        assert monzo._client_id is None
+        assert monzo._client_id is expected_token['client_id']
         assert monzo._client_secret is None
         assert monzo._auth_code is None
         assert monzo._token == expected_token
@@ -127,7 +127,7 @@ class TestMonzoAPI:
         mocked_json_load.assert_called_once_with(mocked_open.return_value)
         mocked_get_oauth_token.assert_called_once_with()
         mocked_oauth2_session.assert_called_once_with(
-            client_id=None,
+            client_id=expected_token['client_id'],
             token=expected_token,
         )
 


### PR DESCRIPTION
- Fixes issue #5 
- Adds being able to not specify the client_secret if you have a valid token. When the functions that use a client_secret are used they will raise 'UnableToGetToken' exception when the client_secret is none.