### PR TITLE
Add support for profile API call

### DIFF
--- a/src/pymonzo/monzo_api.py
+++ b/src/pymonzo/monzo_api.py
@@ -242,14 +242,14 @@ class MonzoAPI(CommonMixin):
         )
 
         return response.json()
-    
+
     def profile(self):
         """
         Get information about the user.
-        
+
         Official docs:
             TBC
-            
+
         :returns: User profile details
         :rtype: dict
         """

--- a/src/pymonzo/monzo_api.py
+++ b/src/pymonzo/monzo_api.py
@@ -242,6 +242,23 @@ class MonzoAPI(CommonMixin):
         )
 
         return response.json()
+    
+    def profile(self):
+        """
+        Get information about the user.
+        
+        Official docs:
+            TBC
+            
+        :returns: User profile details
+        :rtype: dict
+        """
+        endpoint = '/profile'
+        response = self._get_response(
+            method='get', endpoint=endpoint,
+        )
+
+        return response.json()
 
     def accounts(self, refresh=False):
         """

--- a/tests/test_monzo_api.py
+++ b/tests/test_monzo_api.py
@@ -271,6 +271,18 @@ class TestMonzoAPI:
         assert 'user_id' in whoami
 
     @pytest.mark.vcr()
+    def test_class_profile_method(self, monzo):
+        """Test class `profile` method"""
+        profile = monzo.profile()
+
+        assert profile
+        assert isinstance(profile, dict)
+
+        assert 'authenticated' in profile
+        assert 'client_id' in profile
+        assert 'user_id' in profile
+
+    @pytest.mark.vcr()
     def test_class_accounts_method(self, monzo):
         """Test class `accounts` method"""
         accounts = monzo.accounts()


### PR DESCRIPTION
Currently not able to test, as I don't have any API credentials with the `monzo_app` scope. However, the endpoint has been confirmed by Nicholas Robinson-Wall (Monzo Staff) on Slack.