### PR TITLE
v2 API for Pots

### DIFF
--- a/src/pymonzo/api_objects.py
+++ b/src/pymonzo/api_objects.py
@@ -95,7 +95,7 @@ class MonzoPot(MonzoObject):
         """
         self.created = parse_date(data.pop('created'))
 
-    def add(self, amount, account, dedupe):
+    def deposit(self, amount, account, dedupe):
         """
         Adds an amount of whole pence from an account to this pot.
 
@@ -118,7 +118,7 @@ class MonzoPot(MonzoObject):
             },
         )
 
-        return self.__init__(data=response.json(), context=self._context)
+        self.__init__(data=response.json(), context=self._context)
 
     def withdraw(self, amount, account, dedupe):
         """
@@ -143,7 +143,7 @@ class MonzoPot(MonzoObject):
             },
         )
 
-        return self.__init__(data=response.json(), context=self._context)
+        self.__init__(data=response.json(), context=self._context)
 
 
 class MonzoBalance(MonzoObject):

--- a/src/pymonzo/api_objects.py
+++ b/src/pymonzo/api_objects.py
@@ -58,6 +58,9 @@ class MonzoAccount(MonzoObject):
     Class representation of Monzo account
     """
     _required_keys = ['id', 'description', 'created']
+    id = None
+    description = None
+    created = None
 
     def _parse_special_fields(self, data):
         """
@@ -74,6 +77,14 @@ class MonzoPot(MonzoObject):
     Class representation of Monzo pot
     """
     _required_keys = ['id', 'name', 'created', 'style', 'balance', 'currency', 'updated', 'deleted']
+    id = None
+    name = None
+    created = None
+    style = None
+    balance = None
+    currency = None
+    updated = None
+    deleted = None
 
     def _parse_special_fields(self, data):
         """
@@ -84,7 +95,7 @@ class MonzoPot(MonzoObject):
         """
         self.created = parse_date(data.pop('created'))
 
-    def add(self, amount, account):
+    def add(self, amount, account, dedupe):
         """
         Adds an amount of whole pence from an account to this pot.
 
@@ -100,15 +111,16 @@ class MonzoPot(MonzoObject):
         endpoint = '/pots/'+self.id+'/deposit'
         response = self._context._get_response(
             method='put', endpoint=endpoint,
-            params={
-                'account_id': account.id,
+            body={
+                'source_account_id': account.id,
                 'amount': amount,
+                'dedupe_id': dedupe,
             },
         )
 
         return self.__init__(data=response.json(), context=self._context)
 
-    def withdraw(self, amount, account):
+    def withdraw(self, amount, account, dedupe):
         """
         Withdraw an amount of whole pence to an account from this pot.
 
@@ -124,9 +136,10 @@ class MonzoPot(MonzoObject):
         endpoint = '/pots/'+self.id+'/withdraw'
         response = self._context._get_response(
             method='put', endpoint=endpoint,
-            params={
-                'account_id': account.id,
+            body={
+                'destination_account_id': account.id,
                 'amount': amount,
+                'dedupe_id': dedupe,
             },
         )
 

--- a/src/pymonzo/monzo_api.py
+++ b/src/pymonzo/monzo_api.py
@@ -317,16 +317,36 @@ class MonzoAPI(CommonMixin):
         if not refresh and self._cached_pots:
             return self._cached_pots
 
-        endpoint = '/pots/listV1'
+        endpoint = '/pots'
         response = self._get_response(
             method='get', endpoint=endpoint,
         )
 
         pots_json = response.json()['pots']
-        pots = [MonzoPot(data=pot) for pot in pots_json]
+        pots = [MonzoPot(data=pot, context=self) for pot in pots_json]
         self._cached_pots = pots
 
         return pots
+
+    def pot(self, pot_id):
+        """
+        Returns a single pot by ID, owned by the currently authorised user.
+
+        Official docs:
+            https://monzo.com/docs/#pots
+
+        :param pot_id: Pot ID
+        :type pot_id: str
+        :returns: Monzo pot
+        :rtype: MonzoPot
+        """
+
+        endpoint = '/pots/'+pot_id
+        response = self._get_response(
+            method='get', endpoint=endpoint,
+        )
+
+        return MonzoPot(data=response.json(), context=self)
 
     def transactions(self, account_id=None, reverse=True, limit=None):
         """

--- a/src/pymonzo/monzo_api.py
+++ b/src/pymonzo/monzo_api.py
@@ -186,7 +186,7 @@ class MonzoAPI(CommonMixin):
         self._token = token
         self._save_token_on_disk()
 
-    def _get_response(self, method, endpoint, params=None):
+    def _get_response(self, method, endpoint, params=None, body=None):
         """
         Helper method to handle HTTP requests and catch API errors
 
@@ -202,7 +202,7 @@ class MonzoAPI(CommonMixin):
         url = urljoin(self.api_url, endpoint)
 
         try:
-            response = getattr(self._session, method)(url, params=params)
+            response = getattr(self._session, method)(url, params=params, data=body)
 
             # Check if Monzo API returned HTTP 401, which could mean that the
             # token is expired
@@ -268,7 +268,7 @@ class MonzoAPI(CommonMixin):
         )
 
         accounts_json = response.json()['accounts']
-        accounts = [MonzoAccount(data=account) for account in accounts_json]
+        accounts = [MonzoAccount(data=account, context=self) for account in accounts_json]
         self._cached_accounts = accounts
 
         return accounts
@@ -300,7 +300,7 @@ class MonzoAPI(CommonMixin):
             },
         )
 
-        return MonzoBalance(data=response.json())
+        return MonzoBalance(data=response.json(), context=self)
 
     def pots(self, refresh=False):
         """
@@ -389,7 +389,7 @@ class MonzoAPI(CommonMixin):
         if limit:
             transactions = transactions[:limit]
 
-        return [MonzoTransaction(data=t) for t in transactions]
+        return [MonzoTransaction(data=t, context=self) for t in transactions]
 
     def transaction(self, transaction_id, expand_merchant=False):
         """
@@ -415,4 +415,4 @@ class MonzoAPI(CommonMixin):
             method='get', endpoint=endpoint, params=data,
         )
 
-        return MonzoTransaction(data=response.json()['transaction'])
+        return MonzoTransaction(data=response.json()['transaction'], context=self)

--- a/src/pymonzo/utils.py
+++ b/src/pymonzo/utils.py
@@ -28,4 +28,8 @@ class CommonMixin(object):
         return '{}({})'.format(self.__class__.__name__, data)
 
     def __repr__(self):
-        return '{}({})'.format(self.__class__, self.__dict__)
+        data = ', '.join([
+            '{}={}'.format(k, v) for k, v in iteritems(self.__dict__)
+            if not k.startswith('_')
+        ])
+        return '{}({})'.format(self.__class__, data)

--- a/src/pymonzo/utils.py
+++ b/src/pymonzo/utils.py
@@ -28,4 +28,4 @@ class CommonMixin(object):
         return '{}({})'.format(self.__class__.__name__, data)
 
     def __repr__(self):
-         return '{}({})'.format(self.__class__, self.__dict__)
+        return '{}({})'.format(self.__class__, self.__dict__)

--- a/src/pymonzo/utils.py
+++ b/src/pymonzo/utils.py
@@ -28,8 +28,4 @@ class CommonMixin(object):
         return '{}({})'.format(self.__class__.__name__, data)
 
     def __repr__(self):
-        data = ', '.join([
-            '{}={}'.format(k, v) for k, v in iteritems(self.__dict__)
-            if not k.startswith('_')
-        ])
-        return '{}({})'.format(self.__class__, data)
+         return '{}({})'.format(self.__class__, self.__dict__)

--- a/tests/cassettes/TestMonzoAPIIntegration.test_pots_method.yaml
+++ b/tests/cassettes/TestMonzoAPIIntegration.test_pots_method.yaml
@@ -7,10 +7,11 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: https://api.monzo.com/pots/listV1
+    uri: https://api.monzo.com/pots
   response:
-    body: {string: "{\"pots\":[{\"style\":\"rain\",\"id\":\"pot_REDACTED\",\"created\"\
-        :\"2010-01-01T12:00:00.000Z\",\"name\":\"Monthly Savings\",\"deleted\":false,\"currency\":\"GBP\",\"balance\":500}]}"}
+    body: {string: "{\"pots\":[{\"id\":\"pot_REDACTED\",\"name\":\"REDACTED\",\"style\":\"blue_shards\",\"balance\"\
+      :12345,\"currency\":\"GBP\",\"created\":\"2017-12-09T09:57:39.353Z\",\"updated\":\"2018-01-25T11:11:41.12Z\",\
+      \"deleted\":false}]}"}
     headers:
       CF-RAY: [39fe6d7cfed27137-ORD]
       Connection: [keep-alive]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,10 +65,15 @@ def pots_api_response():
     return {
         'pots': [
             {
-                'id': 'acc_00009237aqC8c5umZmrRdh',
-                'name': "Peter Pan's pot",
-                'created': '2015-11-13T12:17:42Z',
-            },
+                "id": "pot_REDACTED",
+                "name": "REDACTED",
+                "style": "blue_shards",
+                "balance": 12345,
+                "currency": "GBP",
+                "created": "2017-12-09T09:57:39.353Z",
+                "updated": "2018-01-25T11:11:41.12Z",
+                "deleted": False
+            }
         ],
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,3 +161,23 @@ def transaction_api_response():
             'settled': '2015-08-23T12:20:18Z',
         },
     }
+
+
+@pytest.fixture(scope='session')
+def pot_api_response():
+    """
+    Helper fixture that returns an example Monzo API 'pot' response
+
+    Source:
+        https://monzo.com/docs/#pots
+    """
+    return {
+        "id": "pot_00009RNZhecjs9zeLKbdcv",
+        "name": "Stuff",
+        "style": "blue_shards",
+        "balance": 12345,
+        "currency": "GBP",
+        "created": "2017-12-09T09:57:39.353Z",
+        "updated": "2018-01-25T11:11:41.12Z",
+        "deleted": False
+    }

--- a/tests/test_api_objects.py
+++ b/tests/test_api_objects.py
@@ -148,7 +148,9 @@ class TestMonzoPot:
 
     def test_class_properties(self, instance):
         """Test class properties"""
-        expected_keys = ['id', 'name', 'created', 'style', 'balance', 'currency', 'updated', 'deleted']
+        expected_keys = [
+            'id', 'name', 'created', 'style', 'balance', 'currency', 'updated','deleted'
+        ]
         assert self.klass._required_keys == expected_keys
         assert instance._required_keys == expected_keys
 

--- a/tests/test_api_objects.py
+++ b/tests/test_api_objects.py
@@ -149,7 +149,7 @@ class TestMonzoPot:
     def test_class_properties(self, instance):
         """Test class properties"""
         expected_keys = [
-            'id', 'name', 'created', 'style', 'balance', 'currency', 'updated','deleted'
+            'id', 'name', 'created', 'style', 'balance', 'currency', 'updated', 'deleted'
         ]
         assert self.klass._required_keys == expected_keys
         assert instance._required_keys == expected_keys
@@ -180,7 +180,7 @@ class TestMonzoPot:
             self.klass(data=data)
 
     def test_class_deposit_method(self, mocker, mocked_monzo,
-                              pots_api_response, accounts_api_response):
+                                  pots_api_response, accounts_api_response):
         """Test class `add` method"""
         mocked_get_response = mocker.patch(
             'pymonzo.monzo_api.MonzoAPI._get_response',

--- a/tests/test_monzo_api.py
+++ b/tests/test_monzo_api.py
@@ -291,7 +291,7 @@ class TestMonzoAPI:
 
         accounts_json = accounts_api_response['accounts']
         expected_result = [
-            MonzoAccount(data=account) for account in accounts_json
+            MonzoAccount(data=account, context=mocked_monzo) for account in accounts_json
         ]
 
         assert result == expected_result
@@ -325,7 +325,7 @@ class TestMonzoAPI:
 
         accounts_json = accounts_api_response['accounts']
         expected_result = [
-            MonzoAccount(data=account) for account in accounts_json
+            MonzoAccount(data=account, context=mocked_monzo) for account in accounts_json
         ]
 
         assert result == expected_result
@@ -354,7 +354,7 @@ class TestMonzoAPI:
             },
         )
 
-        expected_result = MonzoBalance(balance_api_response)
+        expected_result = MonzoBalance(balance_api_response, context=mocked_monzo)
 
         assert result == expected_result
 
@@ -376,11 +376,11 @@ class TestMonzoAPI:
         result = mocked_monzo.pots()
 
         mocked_get_response.assert_called_once_with(
-            method='get', endpoint='/pots/listV1',
+            method='get', endpoint='/pots',
         )
 
         pots_json = pots_api_response['pots']
-        expected_result = [MonzoPot(data=pot) for pot in pots_json]
+        expected_result = [MonzoPot(data=pot, context=mocked_monzo) for pot in pots_json]
 
         assert result == expected_result
         assert mocked_monzo._cached_pots == expected_result
@@ -408,11 +408,11 @@ class TestMonzoAPI:
         result = mocked_monzo.pots(refresh=True)
 
         mocked_get_response.assert_called_once_with(
-            method='get', endpoint='/pots/listV1',
+            method='get', endpoint='/pots',
         )
 
         pots_json = pots_api_response['pots']
-        expected_result = [MonzoPot(data=pot) for pot in pots_json]
+        expected_result = [MonzoPot(data=pot, context=mocked_monzo) for pot in pots_json]
 
         assert result == expected_result
         assert mocked_monzo._cached_pots == expected_result
@@ -442,7 +442,7 @@ class TestMonzoAPI:
 
         transactions_json = transactions_api_response['transactions']
         expected_result = [
-            MonzoTransaction(data=transaction) for transaction in transactions_json
+            MonzoTransaction(data=transaction, context=mocked_monzo) for transaction in transactions_json
         ]
 
         assert result == expected_result
@@ -468,7 +468,7 @@ class TestMonzoAPI:
             params={},
         )
 
-        expected_result = MonzoTransaction(transaction_api_response['transaction'])
+        expected_result = MonzoTransaction(transaction_api_response['transaction'], context=mocked_monzo)
 
         assert result == expected_result
 
@@ -488,6 +488,6 @@ class TestMonzoAPI:
             },
         )
 
-        expected_result = MonzoTransaction(transaction_api_response['transaction'])
+        expected_result = MonzoTransaction(transaction_api_response['transaction'], context=mocked_monzo)
 
         assert result == expected_result

--- a/tests/test_monzo_api.py
+++ b/tests/test_monzo_api.py
@@ -469,8 +469,8 @@ class TestMonzoAPI:
             params={},
         )
 
-        expected_result = MonzoTransaction(transaction_api_response['transaction']
-                                           , context=mocked_monzo)
+        expected_result = MonzoTransaction(transaction_api_response['transaction'],
+                                           context=mocked_monzo)
 
         assert result == expected_result
 

--- a/tests/test_monzo_api.py
+++ b/tests/test_monzo_api.py
@@ -442,7 +442,8 @@ class TestMonzoAPI:
 
         transactions_json = transactions_api_response['transactions']
         expected_result = [
-            MonzoTransaction(data=transaction, context=mocked_monzo) for transaction in transactions_json
+            MonzoTransaction(data=transaction, context=mocked_monzo)
+            for transaction in transactions_json
         ]
 
         assert result == expected_result
@@ -468,7 +469,8 @@ class TestMonzoAPI:
             params={},
         )
 
-        expected_result = MonzoTransaction(transaction_api_response['transaction'], context=mocked_monzo)
+        expected_result = MonzoTransaction(transaction_api_response['transaction']
+                                           , context=mocked_monzo)
 
         assert result == expected_result
 
@@ -488,6 +490,7 @@ class TestMonzoAPI:
             },
         )
 
-        expected_result = MonzoTransaction(transaction_api_response['transaction'], context=mocked_monzo)
+        expected_result = MonzoTransaction(transaction_api_response['transaction'],
+                                           context=mocked_monzo)
 
         assert result == expected_result

--- a/tests/test_monzo_api.py
+++ b/tests/test_monzo_api.py
@@ -494,3 +494,20 @@ class TestMonzoAPI:
                                            context=mocked_monzo)
 
         assert result == expected_result
+
+    def test_class_pot_method(self, mocker, mocked_monzo, pot_api_response):
+        """Test class `pot` method"""
+        mocked_get_response = mocker.patch(
+            'pymonzo.monzo_api.MonzoAPI._get_response',
+        )
+        mocked_get_response.return_value.json.return_value = pot_api_response
+
+        result = mocked_monzo.pot(pot_api_response['id'])
+
+        mocked_get_response.assert_called_once_with(
+            method="get",
+            endpoint="/pots/"+pot_api_response['id']
+        )
+
+        expected_result = MonzoPot(pot_api_response, context=mocked_monzo)
+        assert result == expected_result


### PR DESCRIPTION
Documentation hasn't been released yet, but the `/pots`, `/pots/{id}/deposit` and `/pots/{id}/withdraw` API endpoints are now live. These can be used to list pots and transfer funds between the main amount and each pot. I've also fixed/added the unit tests for them, but haven't added a change log entry yet.

I wasn't sure how you would want the deposit and withdraw functions implemented, as there's not really any like this at the moment. I did them the way I would personally use them, but feel free to suggest changes.