### PR TITLE
Fixes for Pots

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ auth code, which you can get by creating a link like the one below but with your
 client ID:
 
 ```
-https://auth.getmondo.co.uk/?response_type=code&redirect_uri=https://github.com/pawelad/pymonzo&client_id={{CLIENT_ID}}
+https://auth.monzo.com/?response_type=code&redirect_uri=https://github.com/pawelad/pymonzo&client_id={{CLIENT_ID}}
+e.g.
+https://auth.monzo.com/?response_type=code&redirect_uri=https://github.com/pawelad/pymonzo&client_id=oauth2client_0000123456789
 ```
 
 You then go to the link and authorise the app. You should get an email with a

--- a/src/pymonzo/monzo_api.py
+++ b/src/pymonzo/monzo_api.py
@@ -302,7 +302,7 @@ class MonzoAPI(CommonMixin):
 
         return MonzoBalance(data=response.json())
 
-    def pots(self, refresh=False):
+    def pots(self, refresh=False, account_id=None):
         """
         Returns a list of pots owned by the currently authorised user.
 
@@ -316,10 +316,18 @@ class MonzoAPI(CommonMixin):
         """
         if not refresh and self._cached_pots:
             return self._cached_pots
-
-        endpoint = '/pots/listV1'
+        if not account_id:
+            if len(self.accounts()) == 1:
+                account_id = self.accounts()[0].id
+            else:
+                raise ValueError("You need to pass account ID")
+        
+        endpoint = '/pots'
         response = self._get_response(
             method='get', endpoint=endpoint,
+            params={
+                'current_account_id': account_id,
+            },
         )
 
         pots_json = response.json()['pots']


### PR DESCRIPTION
Fix so that Pots matches the current Monzo API endpoint, and passes the current_account_id parameter which is now required