### PR TITLE
Support different accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 ## Unreleased
 
 ### Fixed
+- Add missing account types (by [@csogilvie](https://github.com/csogilvie)).
+  [[#31](https://github.com/pawelad/pymonzo/pull/31)]
 - Add missing space to `NoSettingsFile` exception message.
 
 ## [v2.0.0](https://github.com/pawelad/pymonzo/releases/tag/v2.0.0) - 2024-03-07

--- a/src/pymonzo/accounts/enums.py
+++ b/src/pymonzo/accounts/enums.py
@@ -12,6 +12,9 @@ class MonzoAccountType(str, Enum):
 
     UK_PREPAID = "uk_prepaid"
     UK_RETAIL = "uk_retail"
+    UK_REWARDS = "uk_rewards"
+    UK_BUSINESS = "uk_business"
+    UK_LOAN = "uk_loan"
 
 
 class MonzoAccountCurrency(str, Enum):


### PR DESCRIPTION
Monzo has added different account types, which cause pymonzo validation to fail. This fixes it for my testing.