### PR TITLE
goal_amount is not always present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 ## Unreleased
 
 ### Fixed
+- Monzo pot `goal_amount` is not always present (by [@csogilvie](https://github.com/csogilvie)).
+  [[#32](https://github.com/pawelad/pymonzo/pull/32)]
 - Add missing account types (by [@csogilvie](https://github.com/csogilvie)).
   [[#31](https://github.com/pawelad/pymonzo/pull/31)]
 - Add missing space to `NoSettingsFile` exception message.

--- a/src/pymonzo/pots/schemas.py
+++ b/src/pymonzo/pots/schemas.py
@@ -47,7 +47,7 @@ class MonzoPot(BaseModel):
     deleted: bool
 
     # Undocumented in Monzo API docs
-    goal_amount: int
+    goal_amount: Optional[int] = None
     type: str
     product_id: str
     current_account_id: str


### PR DESCRIPTION
goal_amount is only present for pots when it's enabled on the pot. This sets it as optional, with a default value if not present.