### PR TITLE
Fix pot deposit handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,23 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Changed
 - Stop being strict with certain Monzo enums and allow any string values.
+
   Specifically, account's `type`, `currency` and transaction's `decline_reason`.
 - Changed `empty_str_to_none` logic to be in line with `empty_dict_to_none`.
 
 ### Fixed
+- Use 'form data' instead of 'query params' for relevant Monzo API endpoints.
+
+  Previously, these endpoints (incorrectly) sent request arguments through 'query
+  params' and not 'form data':
+  - `AttachmentsResource.upload()` (`POST /attachment/upload`)
+  - `AttachmentsResource.register()` (`POST /attachment/register`)
+  - `AttachmentsResource.deregister()` (`POST /attachment/deregister`)
+  - `FeedResource.create()` (`POST /feed`)
+  - `PotsResource.deposit()` (`PUT /pots/{pot_id}/deposit`)
+  - `PotsResource.withdraw()` (`PUT /pots/{pot_id}/withdraw`)
+  - `TransactionsResource.annotate()` (`PATCH /transactions/{transaction_id}`)
+  - `WebhooksResource.register()` (`POST /webhooks`)
 - Add (more) missing transaction decline reasons.
   (by [chris987p](https://github.com/chris987p)
   in [#42](https://github.com/pawelad/pymonzo/pull/42))

--- a/src/pymonzo/attachments/resources.py
+++ b/src/pymonzo/attachments/resources.py
@@ -37,12 +37,12 @@ class AttachmentsResource(BaseResource):
             and an `upload_url` to which the file should be uploaded to.
         """
         endpoint = "/attachment/upload"
-        params = {
+        data = {
             "file_name": file_name,
             "file_type": file_type,
             "content_length": content_length,
         }
-        response = self._get_response(method="post", endpoint=endpoint, params=params)
+        response = self._get_response(method="post", endpoint=endpoint, data=data)
 
         attachment_response = MonzoAttachmentResponse(**response.json())
 
@@ -69,12 +69,12 @@ class AttachmentsResource(BaseResource):
             A Monzo attachment.
         """
         endpoint = "/attachment/register"
-        params = {
+        data = {
             "external_id": transaction_id,
             "file_url": file_url,
             "file_type": file_type,
         }
-        response = self._get_response(method="post", endpoint=endpoint, params=params)
+        response = self._get_response(method="post", endpoint=endpoint, data=data)
 
         attachment = MonzoAttachment(**response.json()["attachment"])
 
@@ -93,7 +93,7 @@ class AttachmentsResource(BaseResource):
             API response.
         """
         endpoint = "/attachment/deregister"
-        params = {"id": attachment_id}
-        response = self._get_response(method="post", endpoint=endpoint, params=params)
+        data = {"id": attachment_id}
+        response = self._get_response(method="post", endpoint=endpoint, data=data)
 
         return response.json()

--- a/src/pymonzo/feed/resources.py
+++ b/src/pymonzo/feed/resources.py
@@ -42,18 +42,18 @@ class FeedResource(BaseResource):
         if not account_id:
             account_id = self.client.accounts.get_default_account().id
 
-        params = {
+        data = {
             "account_id": account_id,
             "type": "basic",
         }
 
         for key, value in feed_item.model_dump(exclude_none=True).items():
-            params[f"params[{key}]"] = value
+            data[f"params[{key}]"] = value
 
         if url:
-            params["url"] = url
+            data["url"] = url
 
         endpoint = "/feed"
-        response = self._get_response(method="post", endpoint=endpoint, params=params)
+        response = self._get_response(method="post", endpoint=endpoint, data=data)
 
         return response.json()

--- a/src/pymonzo/pots/resources.py
+++ b/src/pymonzo/pots/resources.py
@@ -188,12 +188,12 @@ class PotsResource(BaseResource):
             dedupe_id = token_urlsafe(16)
 
         endpoint = f"/pots/{pot_id}/withdraw"
-        params = {
+        data = {
             "destination_account_id": account_id,
             "amount": amount,
             "dedupe_id": dedupe_id,
         }
-        response = self._get_response(method="put", endpoint=endpoint, params=params)
+        response = self._get_response(method="put", endpoint=endpoint, data=data)
 
         pot = MonzoPot(**response.json())
 

--- a/src/pymonzo/pots/resources.py
+++ b/src/pymonzo/pots/resources.py
@@ -136,12 +136,12 @@ class PotsResource(BaseResource):
             dedupe_id = token_urlsafe(16)
 
         endpoint = f"/pots/{pot_id}/deposit"
-        params = {
+        data = {
             "source_account_id": account_id,
             "amount": amount,
             "dedupe_id": dedupe_id,
         }
-        response = self._get_response(method="put", endpoint=endpoint, params=params)
+        response = self._get_response(method="put", endpoint=endpoint, data=data)
 
         pot = MonzoPot(**response.json())
 

--- a/src/pymonzo/resources.py
+++ b/src/pymonzo/resources.py
@@ -44,11 +44,11 @@ class BaseResource:
             MonzoAccessDenied: When access to Monzo API was denied.
             MonzoAPIError: When Monzo API returned an error.
         """
-        kwargs = {"params": params}
-        if method in ["post", "put", "delete"]:
-            kwargs["data"] = data
+        httpx_kwargs = {"params": params}
+        if method in ["post", "put", "patch"]:
+            httpx_kwargs["data"] = data
 
-        response = getattr(self.client.session, method)(endpoint, **kwargs)
+        response = getattr(self.client.session, method)(endpoint, **httpx_kwargs)
 
         if response.status_code == codes.FORBIDDEN:
             raise MonzoAccessDenied(

--- a/src/pymonzo/resources.py
+++ b/src/pymonzo/resources.py
@@ -44,7 +44,11 @@ class BaseResource:
             MonzoAccessDenied: When access to Monzo API was denied.
             MonzoAPIError: When Monzo API returned an error.
         """
-        response = getattr(self.client.session, method)(endpoint, params=params, data=data)
+        kwargs = {"params": params}
+        if method in ["post", "put", "delete"]:
+            kwargs["data"] = data
+
+        response = getattr(self.client.session, method)(endpoint, **kwargs)
 
         if response.status_code == codes.FORBIDDEN:
             raise MonzoAccessDenied(

--- a/src/pymonzo/resources.py
+++ b/src/pymonzo/resources.py
@@ -35,7 +35,8 @@ class BaseResource:
         Arguments:
             method: HTTP method.
             endpoint: HTTP endpoint.
-            params: HTTP params.
+            params: URL query parameters.
+            data: form encoded data.
 
         Returns:
             HTTP response.

--- a/src/pymonzo/resources.py
+++ b/src/pymonzo/resources.py
@@ -28,6 +28,7 @@ class BaseResource:
         method: str,
         endpoint: str,
         params: Optional[dict] = None,
+        data: Optional[dict] = None,
     ) -> httpx.Response:
         """Handle HTTP requests and catch API errors.
 
@@ -43,7 +44,7 @@ class BaseResource:
             MonzoAccessDenied: When access to Monzo API was denied.
             MonzoAPIError: When Monzo API returned an error.
         """
-        response = getattr(self.client.session, method)(endpoint, params=params)
+        response = getattr(self.client.session, method)(endpoint, params=params, data=data)
 
         if response.status_code == codes.FORBIDDEN:
             raise MonzoAccessDenied(

--- a/src/pymonzo/transactions/resources.py
+++ b/src/pymonzo/transactions/resources.py
@@ -62,9 +62,9 @@ class TransactionsResource(BaseResource):
             Annotated Monzo transaction.
         """
         endpoint = f"/transactions/{transaction_id}"
-        params = {f"metadata[{key}]": value for key, value in metadata.items()}
+        data = {f"metadata[{key}]": value for key, value in metadata.items()}
 
-        response = self._get_response(method="patch", endpoint=endpoint, params=params)
+        response = self._get_response(method="patch", endpoint=endpoint, data=data)
 
         transaction = MonzoTransaction(**response.json()["transaction"])
 

--- a/src/pymonzo/webhooks/resources.py
+++ b/src/pymonzo/webhooks/resources.py
@@ -68,11 +68,11 @@ class WebhooksResource(BaseResource):
             account_id = self.client.accounts.get_default_account().id
 
         endpoint = "/webhooks"
-        params = {
+        data = {
             "account_id": account_id,
             "url": url,
         }
-        response = self._get_response(method="post", endpoint=endpoint, params=params)
+        response = self._get_response(method="post", endpoint=endpoint, data=data)
 
         webhook = MonzoWebhook(**response.json()["webhook"])
 

--- a/tests/pymonzo/test_attachments.py
+++ b/tests/pymonzo/test_attachments.py
@@ -44,7 +44,7 @@ class TestAttachmentsResource:
 
         mocked_route = respx_mock.post(
             "/attachment/upload",
-            params={
+            data={
                 "file_name": file_name,
                 "file_type": file_type,
                 "content_length": content_length,
@@ -79,7 +79,7 @@ class TestAttachmentsResource:
 
         mocked_route = respx_mock.post(
             "/attachment/register",
-            params={
+            data={
                 "external_id": transaction_id,
                 "file_url": file_url,
                 "file_type": file_type,
@@ -111,7 +111,7 @@ class TestAttachmentsResource:
 
         mocked_route = respx_mock.post(
             "/attachment/deregister",
-            params={"id": attachment_id},
+            data={"id": attachment_id},
         ).mock(return_value=httpx.Response(200, json={}))
 
         attachment_deregister_response = attachments_resource.deregister(attachment_id)

--- a/tests/pymonzo/test_feed.py
+++ b/tests/pymonzo/test_feed.py
@@ -42,23 +42,23 @@ class TestFeedResource:
         )
         mocked_get_default_account.return_value = account
 
-        params = {
+        data = {
             "account_id": account.id,
             "type": "basic",
             "params[title]": feed_item.title,
             "params[image_url]": feed_item.image_url,
             "params[body]": feed_item.body,
         }
-        optional_params = {
+        optional_data = {
             "params[background_color]": feed_item.background_color,
             "params[title_color]": feed_item.title_color,
             "params[body_color]": feed_item.body_color,
         }
-        for key, value in optional_params.items():
+        for key, value in optional_data.items():
             if value is not None:
-                params[key] = str(value)
+                data[key] = str(value)
 
-        mocked_route = respx_mock.post("/feed", params=params).mock(
+        mocked_route = respx_mock.post("/feed", data=data).mock(
             return_value=httpx.Response(200, json={})
         )
 
@@ -74,7 +74,7 @@ class TestFeedResource:
         account_id = "TEST_ACCOUNT_ID"
         url = "TEST_URL"
 
-        params = {
+        data = {
             "account_id": account_id,
             "type": "basic",
             "url": url,
@@ -82,16 +82,16 @@ class TestFeedResource:
             "params[image_url]": feed_item.image_url,
             "params[body]": feed_item.body,
         }
-        optional_params = {
+        optional_data = {
             "params[background_color]": feed_item.background_color,
             "params[title_color]": feed_item.title_color,
             "params[body_color]": feed_item.body_color,
         }
-        for key, value in optional_params.items():
+        for key, value in optional_data.items():
             if value is not None:
-                params[key] = str(value)
+                data[key] = str(value)
 
-        mocked_route = respx_mock.post("/feed", params=params).mock(
+        mocked_route = respx_mock.post("/feed", data=data).mock(
             return_value=httpx.Response(200, json={})
         )
 

--- a/tests/pymonzo/test_pots.py
+++ b/tests/pymonzo/test_pots.py
@@ -180,12 +180,12 @@ class TestPotsResource:
         # Mock `httpx`
         amount = 42
         endpoint = f"/pots/{pot.id}/deposit"
-        params = {
+        data = {
             "source_account_id": account.id,
             "amount": amount,
             "dedupe_id": token,
         }
-        mocked_route = respx_mock.put(endpoint, params=params).mock(
+        mocked_route = respx_mock.put(endpoint, data=data).mock(
             return_value=httpx.Response(
                 200,
                 json=pot.model_dump(mode="json"),
@@ -213,12 +213,12 @@ class TestPotsResource:
 
         amount = 42
         endpoint = f"/pots/{pot_id}/deposit"
-        params = {
+        data = {
             "source_account_id": account_id,
             "amount": amount,
             "dedupe_id": dedupe_id,
         }
-        mocked_route = respx_mock.put(endpoint, params=params).mock(
+        mocked_route = respx_mock.put(endpoint, data=data).mock(
             return_value=httpx.Response(
                 200,
                 json=pot.model_dump(mode="json"),
@@ -279,12 +279,12 @@ class TestPotsResource:
         # Mock `httpx`
         amount = 42
         endpoint = f"/pots/{pot.id}/withdraw"
-        params = {
+        data = {
             "destination_account_id": account.id,
             "amount": amount,
             "dedupe_id": token,
         }
-        mocked_route = respx_mock.put(endpoint, params=params).mock(
+        mocked_route = respx_mock.put(endpoint, data=data).mock(
             return_value=httpx.Response(
                 200,
                 json=pot.model_dump(mode="json"),
@@ -312,12 +312,12 @@ class TestPotsResource:
 
         amount = 42
         endpoint = f"/pots/{pot_id}/withdraw"
-        params = {
+        data = {
             "destination_account_id": account_id,
             "amount": amount,
             "dedupe_id": dedupe_id,
         }
-        mocked_route = respx_mock.put(endpoint, params=params).mock(
+        mocked_route = respx_mock.put(endpoint, data=data).mock(
             return_value=httpx.Response(
                 200,
                 json=pot.model_dump(mode="json"),

--- a/tests/pymonzo/test_transactions.py
+++ b/tests/pymonzo/test_transactions.py
@@ -141,13 +141,14 @@ class TestTransactionsResource:
             "foo": "TEST_FOO",
             "bar": "TEST_BAR",
         }
+        data = {
+            "metadata[foo]": "TEST_FOO",
+            "metadata[bar]": "TEST_BAR",
+        }
 
         mocked_route = respx_mock.patch(
             f"/transactions/{transaction.id}",
-            params={
-                "metadata[foo]": "TEST_FOO",
-                "metadata[bar]": "TEST_BAR",
-            },
+            data=data,
         ).mock(
             return_value=httpx.Response(
                 200,

--- a/tests/pymonzo/test_webhooks.py
+++ b/tests/pymonzo/test_webhooks.py
@@ -109,13 +109,12 @@ class TestWebhooksResource:
         )
         mocked_get_default_account.return_value = account
 
-        mocked_route = respx_mock.post(
-            "/webhooks",
-            params={
-                "account_id": account.id,
-                "url": url,
-            },
-        ).mock(
+        data = {
+            "account_id": account.id,
+            "url": url,
+        }
+
+        mocked_route = respx_mock.post("/webhooks", data=data).mock(
             return_value=httpx.Response(
                 200,
                 json={"webhook": webhook.model_dump(mode="json")},
@@ -132,14 +131,12 @@ class TestWebhooksResource:
 
         # Explicitly passed account ID
         account_id = "TEST_ACCOUNT_ID"
+        data = {
+            "account_id": account_id,
+            "url": url,
+        }
 
-        mocked_route = respx_mock.post(
-            "/webhooks",
-            params={
-                "account_id": account_id,
-                "url": url,
-            },
-        ).mock(
+        mocked_route = respx_mock.post("/webhooks", data=data).mock(
             return_value=httpx.Response(
                 200,
                 json={"webhook": webhook.model_dump(mode="json")},
@@ -147,7 +144,8 @@ class TestWebhooksResource:
         )
 
         webhooks_register_response = webhooks_resource.register(
-            url=url, account_id=account_id
+            url=url,
+            account_id=account_id,
         )
 
         mocked_get_default_account.assert_not_called()


### PR DESCRIPTION
I got [this](https://community.monzo.com/t/adding-money-to-pots-returns-an-error-that-the-value-must-be-more-than-0/108829/11) issue when trying to make a deposit into a pot.

I found that it was due to "[the fact the data was in the query string and not the body](https://community.monzo.com/t/adding-money-to-pots-returns-an-error-that-the-value-must-be-more-than-0/108829/12)".

This is likely an issue across the library, but the change offered in this PR is what I needed for my purposes.