### PR TITLE
docs: add AGENTS.md for AI agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,28 +1,42 @@
-# Guidelines for AI Agents
+# AI Agent Instructions (`AGENTS.md`)
 
-Welcome! If you are an AI agent working on `pymonzo`, please follow these instructions.
+This document defines the strict, non-negotiable guidelines for any AI agent interacting with the `pymonzo` codebase. Read it fully before performing any work.
 
-For additional context about the project, refer to the [README.md](./README.md) and [CONTRIBUTING.md](./CONTRIBUTING.md) files.
+## Project References
 
-## General Information
-- The project is written in Python 3.9+.
-- The codebase is heavily typed and uses `pydantic` for API schema validation.
+Always consult these files first for context, standards, and setup instructions:
 
-## Tools
-- `make` is used for running various common tasks (see `Makefile` for available commands).
-- `nox` is used to run tests across different python versions, and for linting/type-checking.
+| File | Purpose |
+|---|---|
+| [`README.md`](README.md) | Project overview, high-level architecture, and installation. |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | Coding standards, tooling reference, and CI details. |
+| [`CHANGELOG.md`](CHANGELOG.md) | Change history. |
+| [`Makefile`](Makefile) | Source of truth for all dev automation - always prefer `make` over raw commands. |
+| [`pyproject.toml`](pyproject.toml) | Dependency groups, build definitions, and tool config (`black`, `isort`, `ruff`, `mypy`, `pytest`, `interrogate`). |
+| [`noxfile.py`](noxfile.py) | Nox sessions run by CI: `tests`, `coverage_report`, `code_style_checks`, `type_checks`, `docs`. |
 
-## Code Style and Formatting
-- The project uses `black`, `isort`, and `ruff` for code style and linting.
-- To format the code, run: `make format`
+## Project Context & Toolchain
 
-## Testing
-- Tests are written with `pytest`.
-- Run tests via `make test` or `nox`.
+- **Core Identity**: `pymonzo` is a modern Python API client for the Monzo public API.
+- **Python Version**: Python 3.9+.
+- **Typing & Validation**: The codebase is strictly typed and utilizes `pydantic` extensively for defining and validating API schemas.
+- **`make` is the Source of Truth**: Never run raw tool commands when a `make` target exists. Run `make help` for the full list.
+- **Formatting**: Always use `make format` (`black` + `isort` + `ruff check --fix`). Never run formatters directly.
+- **Testing**: Always use `make test` which invokes `nox`.
 
-## Type Checking
-- Run type checks using `mypy`. This is available via the `nox` configuration.
+## The "Do Not" List
 
-## Submitting Changes
-- Always make sure `make format` and `make test` are passing before finalizing your changes.
-- Remember to update documentation if you modify API signatures or behavior.
+- **Do not hallucinate files or states.** Verify paths exist before reading or writing.
+- **Do not run raw formatters.** Always use `make format`.
+- **Do not skip tests.** New functionality without tests will be rejected.
+- **Do not forget to update types/schemas.** If a Monzo API signature changes, the associated `pydantic` schemas must be updated.
+- **Do not commit without formatting.** `make format` must pass cleanly.
+
+## Pre-flight Checklist
+
+Before concluding any task, verify each item:
+
+- [ ] Did I run `make format` and does it pass cleanly?
+- [ ] Did I run `make test` and do the relevant core tests pass?
+- [ ] If I modified API behavior, did I update the corresponding `pydantic` schemas?
+- [ ] If I modified API signatures, did I ensure that typing and docstrings were updated?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# Guidelines for AI Agents
+
+Welcome! If you are an AI agent working on `pymonzo`, please follow these instructions:
+
+## General Information
+- The project is written in Python 3.9+.
+- The codebase is heavily typed and uses `pydantic` for API schema validation.
+
+## Tools
+- `make` is used for running various common tasks (see `Makefile` for available commands).
+- `nox` is used to run tests across different python versions, and for linting/type-checking.
+
+## Code Style and Formatting
+- The project uses `black`, `isort`, and `ruff` for code style and linting.
+- To format the code, run: `make format`
+
+## Testing
+- Tests are written with `pytest`.
+- Run tests via `make test` or `nox`.
+
+## Type Checking
+- Run type checks using `mypy`. This is available via the `nox` configuration.
+
+## Submitting Changes
+- Always make sure `make format` and `make test` are passing before finalizing your changes.
+- Remember to update documentation if you modify API signatures or behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # Guidelines for AI Agents
 
-Welcome! If you are an AI agent working on `pymonzo`, please follow these instructions:
+Welcome! If you are an AI agent working on `pymonzo`, please follow these instructions.
+
+For additional context about the project, refer to the [README.md](./README.md) and [CONTRIBUTING.md](./CONTRIBUTING.md) files.
 
 ## General Information
 - The project is written in Python 3.9+.


### PR DESCRIPTION
Adds `AGENTS.md` to document codebase conventions, tools, and guidelines for AI agents working on `pymonzo`.

---
*PR created automatically by Jules for task [17867323023326440648](https://jules.google.com/task/17867323023326440648) started by @pawelad*