### PR TITLE
🧪 [testing improvement] JSONDecodeError path in _get_response

### DIFF
--- a/tests/pymonzo/test_resources.py
+++ b/tests/pymonzo/test_resources.py
@@ -73,3 +73,16 @@ class TestBaseResource:
             base_resource._get_response(method="get", endpoint="/http500")
 
         assert mocked_route.called
+
+    def test__get_response_json_decode_error(
+        self, respx_mock: respx.MockRouter, base_resource: BaseResource
+    ) -> None:
+        """JSONDecodeError in response body is handled."""
+        mocked_route = respx_mock.get("/non-json").mock(
+            return_value=httpx.Response(500, content=b"Not a JSON")
+        )
+
+        with pytest.raises(MonzoAPIError, match=r"Something went wrong: .*"):
+            base_resource._get_response(method="get", endpoint="/non-json")
+
+        assert mocked_route.called


### PR DESCRIPTION
🎯 **What:** Missing error path test for JSONDecodeError in _get_response
📊 **Coverage:** Added test case for non-JSON API error responses in `BaseResource._get_response`
✨ **Result:** Improved robustness of error handling verification by ensuring `JSONDecodeError` is correctly handled when the API returns a non-JSON body on error.

---
*PR created automatically by Jules for task [208700039616270909](https://jules.google.com/task/208700039616270909) started by @pawelad*