### PR TITLE
Set optimal fixture scope for resources

### DIFF
--- a/tests/pymonzo/test_accounts.py
+++ b/tests/pymonzo/test_accounts.py
@@ -22,9 +22,7 @@ class MonzoAccountFactory(ModelFactory[MonzoAccount]):
     """Factory for `MonzoAccount` schema."""
 
 
-# TODO: What should be resources fixture scope?
-#   With `module`, `_cached_accounts` value persisted between functions / tests.
-@pytest.fixture()
+@pytest.fixture(scope="function")
 def accounts_resource(monzo_api: MonzoAPI) -> AccountsResource:
     """Initialize `AccountsResource` resource with `monzo_api` fixture."""
     return AccountsResource(client=monzo_api)

--- a/tests/pymonzo/test_pots.py
+++ b/tests/pymonzo/test_pots.py
@@ -19,7 +19,7 @@ class MonzoPotFactory(ModelFactory[MonzoPot]):
     """Factory for `MonzoPot` schema."""
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def pots_resource(monzo_api: MonzoAPI) -> PotsResource:
     """Initialize `PotsResource` resource with `monzo_api` fixture."""
     return PotsResource(client=monzo_api)


### PR DESCRIPTION
Set the optimal fixture scope for `AccountsResource` and `PotsResource` to `function`. This ensures each test starts with a fresh instance, avoiding side effects from internal caching of API responses. Removed the related TODO in `test_accounts.py`.

---
*PR created automatically by Jules for task [6090339659672356690](https://jules.google.com/task/6090339659672356690) started by @pawelad*